### PR TITLE
Fix the last two broken cities in Québec in cities.json

### DIFF
--- a/lib/cities.json
+++ b/lib/cities.json
@@ -447,12 +447,12 @@
           "provinceShort": "QC"
         },
         {
-          "name": "Saint Jerome",
+          "name": "Saint-Jérôme",
           "province": "Quebec",
           "provinceShort": "QC"
         },
         {
-          "name": "Saint Jean-sur-Richelieu",
+          "name": "Saint-Jean-sur-Richelieu",
           "province": "Quebec",
           "provinceShort": "QC"
         },


### PR DESCRIPTION
Saint-Jérôme and Saint-Jean-sur-Richelieu in Québec are broken in the weather app (originally for a reason, yet now in the portfolio this could end up backfiring on you when an employer looks at the app). This has been fixed, so both cities now function correctly.